### PR TITLE
Fix android apk build workflow

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -14,17 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: android-actions/setup-android@v3
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;27.1.12297006"
           yes | sdkmanager --licenses
       - name: Install NPM deps
         working-directory: FPVDroneGame
@@ -34,7 +36,10 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build release
         working-directory: FPVDroneGame/android
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --no-daemon --stacktrace
+        env:
+          ANDROID_HOME: ${{ env.ANDROID_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
       - name: Find APK
         id: apk
         run: echo "path=$(find FPVDroneGame/android/app/build/outputs/apk/release -name '*.apk' -print -quit)" >> $GITHUB_OUTPUT

--- a/FPVDroneGame/android/build.gradle
+++ b/FPVDroneGame/android/build.gradle
@@ -31,6 +31,27 @@ allprojects {
     mavenCentral()
     maven { url 'https://www.jitpack.io' }
   }
+  
+  // Fix for expo-gl-cpp classifier deprecation warning
+  afterEvaluate { project ->
+    if (project.name == 'expo-gl-cpp') {
+      project.tasks.withType(org.gradle.api.tasks.bundling.Jar) { task ->
+        if (task.name == 'androidSourcesJar') {
+          task.archiveClassifier = 'sources'
+        }
+      }
+    }
+  }
+}
+
+// Define Android SDK versions for all modules
+ext {
+    buildToolsVersion = "35.0.0"
+    minSdkVersion = 24
+    compileSdkVersion = 35
+    targetSdkVersion = 35
+    ndkVersion = "27.1.12297006"
+    kotlinVersion = "2.0.21"
 }
 
 apply plugin: "expo-root-project"

--- a/FPVDroneGame/android/settings.gradle
+++ b/FPVDroneGame/android/settings.gradle
@@ -29,6 +29,8 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
     ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand)
   }
 }
+
+// Configure Expo autolinking
 expoAutolinking.useExpoModules()
 
 rootProject.name = 'FPV Drone Racing'


### PR DESCRIPTION
Fixes Android APK build workflow by addressing SDK version definitions, Gradle compatibility issues, and workflow configurations.

The previous workflow failed due to undefined Android SDK versions, a deprecated `classifier` property in `expo-gl-cpp` with newer Gradle, and Java version incompatibility. This PR defines necessary SDK versions, adds a workaround for the `classifier` issue, updates Java to 21, and improves the GitHub Actions setup for a successful build.

---
<a href="https://cursor.com/background-agent?bcId=bc-9060ef09-7192-4dcd-85bc-961b39df73f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9060ef09-7192-4dcd-85bc-961b39df73f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

