### PR TITLE
Setup android sdk and npm install

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -1,4 +1,4 @@
-name: android-apk
+name: build-android-apk
 on:
   push:
     tags:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;27.1.12297006"
           yes | sdkmanager --licenses
 
       - name: Fix Git URL for npm (prevent exit 128)
@@ -44,19 +44,23 @@ jobs:
           git config --global url."https://".insteadOf "git://"
 
       - name: Install npm deps
+        working-directory: FPVDroneGame
         run: npm ci --legacy-peer-deps
 
       - name: Gradle perms
-        working-directory: android
+        working-directory: FPVDroneGame/android
         run: chmod +x ./gradlew
 
       - name: Build release
-        working-directory: android
-        run: ./gradlew assembleRelease
+        working-directory: FPVDroneGame/android
+        run: ./gradlew assembleRelease --no-daemon --stacktrace
+        env:
+          ANDROID_HOME: ${{ env.ANDROID_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
 
       - name: Find APK
         id: apk
-        run: echo "path=$(find android/app/build/outputs/apk/release -name '*.apk' -print -quit)" >> $GITHUB_OUTPUT
+        run: echo "path=$(find FPVDroneGame/android/app/build/outputs/apk/release -name '*.apk' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes the Android APK build workflow by correcting working directories and adding necessary SDK components.

The `build-android-apk.yml` workflow was failing because `npm ci` was executed in the wrong directory, leading to a missing `package-lock.json` error. Additionally, Android build steps used incorrect paths, and the NDK was not installed, preventing a successful build. This PR addresses these issues and resolves a workflow name conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-d41ebaa9-86c1-4c92-89b5-be30be4aa13f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d41ebaa9-86c1-4c92-89b5-be30be4aa13f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

